### PR TITLE
added bcrypt for pass-hashing to user model

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -1,3 +1,5 @@
+var bcrypt = require("bcrypt-nodejs");
+
 module.exports = function(sequelize, DataTypes) {
   var User = sequelize.define("User", {
     name: {
@@ -18,7 +20,7 @@ module.exports = function(sequelize, DataTypes) {
       defaultValue: 2.5
     },
     userName: {
-      type: DataTypes.TEXT
+      type: DataTypes.STRING
     },
     password: {
       type: DataTypes.STRING,
@@ -33,6 +35,16 @@ module.exports = function(sequelize, DataTypes) {
     }
   });
 
+  User.prototype.validPassword = function(password) {
+    return bcrypt.compareSync(password, this.password);
+  };
+  User.hook("beforeCreate", function(user) {
+    user.password = bcrypt.hashSync(
+      user.password,
+      bcrypt.genSaltSync(10),
+      null
+    );
+  });
   User.associate = function(models) {
     // Associating User with Items
     User.hasMany(models.Item, {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,6 +183,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "bcrypt-nodejs": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/bcrypt-nodejs/-/bcrypt-nodejs-0.0.3.tgz",
+      "integrity": "sha1-xgkX8m3CNWYVZsaBBhwwPCsohCs="
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "bcrypt-nodejs": "0.0.3",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",
     "express-handlebars": "^3.0.0",

--- a/public/js/signup.js
+++ b/public/js/signup.js
@@ -10,9 +10,8 @@ var logInSubmit = $(".login-form-submit");
 $(document).ready(function() {
   signUpSubmit.on("click", function(e) {
     e.preventDefault();
-
     $.post("/api/sign-up", {
-      username: signUpUsername.val().trim(),
+      userName: signUpUsername.val().trim(),
       password: signUpPassword.val().trim(),
       bio: signUpBio.val().trim(),
       name: signUpName.val().trim(),


### PR DESCRIPTION
if you use the signup modal, then check the users table, you will see the hashed pass word.

the hashing is done "before" the user is created so the unhashed pw is never saved or stored outside of the front end.

also, i fixed a little bug in the user model; we had the userName set as "text" instead of a "string" which was messing with everything