### PR TITLE
Fix items not popup issue

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -15,11 +15,7 @@
     "logging": false
   },
   "production": {
-    "username": "e5zqedttl8m62hj8",
-    "password": "uyzdt2wnclpvl0d4",
-    "database": "fgswcxmvkvql7qa1",
-    "host": "p1us8ottbqwio8hv.cbetxkdyhwsb.us-east-1.rds.amazonaws.com",
-    "port": 3306,
+    "use_env_variable": "JAWSDB_URL",
     "dialect": "mysql"
   }
 }

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -99,7 +99,18 @@ module.exports = function(app) {
       imageURL: req.body.imageURL,
       UserId: req.user.id
     }).then(function(dbItem) {
-      //console.log(dbItem);
+      
+      //When a new chosen item is selected, 
+      //a upVote value is added to the Vote table
+      //for displaying purpose 
+      //(if no vote value, then no item will be displayed 
+      //-- See htmlRoutes for the logic!)
+      db.Vote.create({
+        voteValue: 1,
+        ItemId: dbItem.dataValues.id,
+        UserId: req.user.id
+      });
+
       res.json(dbItem);
     });
   });


### PR DESCRIPTION
1. Fix the popup issue (due to votes logic in the htmlRoutes): 
What I find is that all items need to have _at least one vote_ in order to be loaded up onto the index page (index.handlebars). As a result, I add a short code to add 1 vote when a new item is submitted. So when a new item is created, you will see the pop-up on the index page!

2. I change the production section of the config.json file to set up the database to link with the addons: JawsDB. 